### PR TITLE
fix: restore hyperlinks on sign-up and docs bullet points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,242 @@
 # Go Feature Flag SDK for TestMu AI (Formerly LambdaTest)
 
+
+
 <p align="center">
+
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+
   <a href="https://pkg.go.dev/github.com/LambdaTest/lambda-featureflag-go-sdk"><img src="https://img.shields.io/github/v/release/LambdaTest/lambda-featureflag-go-sdk.svg?style=for-the-badge&labelColor=000000" alt="Go package"></a>
+
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+
 </p>
+
+
 
 ## Getting Started
 
+
+
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
+
+
 
 With TestMu AI (Formerly LambdaTest), you can integrate the Go Feature Flag SDK for feature flag evaluation in your Go-based test suites and applications.
 
-- Sign up on TestMu AI (Formerly LambdaTest).
-- Follow the TestMu AI Documentation for the full setup walkthrough.
+
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+
+
 
 ### Prerequisites
 
+
+
 1. Go 1.18 or higher installed.
+
 2. A TestMu AI account — sign up here.
+
 3. Your TestMu AI Username and Access Key from the Automation Dashboard.
+
 4. An Amplitude server-side deployment key for feature flag evaluation.
+
+
 
 ### Setup
 
+
+
 Clone the repository:
 
+
+
 ```bash
+
 git clone https://github.com/LambdaTest/lambda-featureflag-go-sdk
+
 cd lambda-featureflag-go-sdk
+
 ```
+
+
 
 Add the SDK to your `go.mod`:
 
+
+
 ```
+
 github.com/LambdaTest/lambda-featureflag-go-sdk latest
+
 ```
+
+
 
 Install dependencies:
 
+
+
 ```bash
+
 go mod vendor
+
 ```
+
+
 
 Configure the required environment variables:
 
+
+
 ```bash
+
 LOCAL_EVALUATION_CONFIG_DEBUG=false
+
 LOCAL_EVALUATION_CONFIG_SERVER_URL="https://api.lab.amplitude.com/"
+
 LOCAL_EVALUATION_CONFIG_POLL_INTERVAL=30
+
 LOCAL_EVALUATION_CONFIG_POLLER_REQUEST_TIMEOUT=10
+
 LOCAL_EVALUATION_DEPLOYMENT_KEY="your-server-side-deployment-key"
+
 ```
+
+
 
 ### Run tests
 
+
+
 Run the Go tests locally:
 
+
+
 ```bash
+
 go test ./...
+
 ```
+
+
 
 ### Local testing with TestMu AI Tunnel
 
+
+
 To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
+
+
 - [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+
 - [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+
 - [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+
 
 Configure tunnel in your test capabilities:
 
+
+
 ```go
+
 capabilities := map[string]interface{}{
+
     "tunnel": true,
+
 }
+
 ```
+
+
 
 ## Contributions
 
+
+
 Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Go version, OS, and go.mod details.
+
+
 
 ## TestMu AI (Formerly LambdaTest) Community
 
+
+
 Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+
   
+
 ## TestMu AI (Formerly LambdaTest) Certifications
+
+
 
 Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
+
+
 ## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+
 
 Learn modern testing through tutorials, guides, videos, and weekly updates:
 
+
+
 * [TestMu AI Blog](https://www.testmuai.com/blog/)
+
 * [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+
 * [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+
 * [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+
   
+
 ## LambdaTest is Now TestMu AI
+
+
 
 On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
+
+
 Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+
 
 ð Find the new home for [LambdaTest](https://www.testmuai.com).
 
+
+
 ### How LambdaTest Evolved into TestMu AI
+
+
 
 In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
+
+
 As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+
 
 That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
+
+
 What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+
 
 ## Support
 
+
+
 Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.
+


### PR DESCRIPTION
Restores the markdown hyperlinks on the sign-up and documentation bullet points under Getting Started that were incorrectly stripped to plain text.